### PR TITLE
Normal Font Weight

### DIFF
--- a/src/components/home.css
+++ b/src/components/home.css
@@ -54,7 +54,7 @@ div.hr {
 }
 
 .skill-item {
-	font-weight: 900;
+	font-weight: bold;
 }
 
 /* mobile portrait layout */


### PR DESCRIPTION
Changed skill item font weight to bold. The skill item font weight should not be 900 because it is too bold for my liking. 